### PR TITLE
Create app module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,32 @@
+import {NgModule} from "@angular/core";
+import {HttpModule} from "@angular/http";
+
+import assign from "lodash/assign";
+
+import {App} from "./app.component";
+import {APP_ROUTES, appRoutingProviders} from "./app.routes";
+import {createStoreProvider} from "./app.store";
+import {InputModule} from "./inputTest/input.module";
+import {TodosModule} from "./todos/todos.module";
+
+let initialState = {};
+
+const IMPORTS = [
+  HttpModule,
+  APP_ROUTES,
+  InputModule,
+  TodosModule,
+  createStoreProvider(initialState)
+];
+
+@NgModule({
+  imports: IMPORTS,
+  providers: [appRoutingProviders],
+  declarations: [App],
+  bootstrap: [App]
+})
+export class AppModule {
+  static extendInitialState(state: any) {
+    assign(initialState, state);
+  }
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,7 @@ import assign from "lodash/assign";
 import {App} from "./app.component";
 import {APP_ROUTES, appRoutingProviders} from "./app.routes";
 import {createStoreProvider} from "./app.store";
-import {InputModule} from "./inputTest/input.module";
+import {InputTestModule} from "./inputTest/inputTest.module";
 import {TodosModule} from "./todos/todos.module";
 
 let initialState = {};
@@ -14,7 +14,7 @@ let initialState = {};
 const IMPORTS = [
   HttpModule,
   APP_ROUTES,
-  InputModule,
+  InputTestModule,
   TodosModule,
   createStoreProvider(initialState)
 ];

--- a/src/app/inputTest/inputTest.module.ts
+++ b/src/app/inputTest/inputTest.module.ts
@@ -25,5 +25,5 @@ import {INPUT_TEST_ROUTES} from "./inputTest.routes";
   exports: [TranslateModule],
   declarations: [InputTestComponent]
 })
-export class InputModule {
+export class InputTestModule {
 }

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -1,57 +1,22 @@
 import "zone.js";
 import "reflect-metadata";
-
-import assign from "lodash/assign";
-
-import {platformBrowserDynamic} from "@angular/platform-browser-dynamic";
-import {NgModule} from "@angular/core";
-import {HttpModule} from "@angular/http";
-
-import {Store} from "@ngrx/store";
-
 import "rxjs/add/operator/take";
 
-import {App} from "./app/app.component";
-import {APP_ROUTES, appRoutingProviders} from "./app/app.routes";
-import {createStoreProvider} from "./app/app.store";
-import {InputModule} from "./app/inputTest/input.module";
-import {TodosModule} from "./app/todos/todos.module";
+import {platformBrowserDynamic} from "@angular/platform-browser-dynamic";
+import {Store} from "@ngrx/store";
+import {AppModule} from "./app/app.module";
 
+let storeHolder: any = {};
 
-let storeHolder: {
-  store?: Store<any>
-} = {};
-let targetState: any = {};
+// A callback which is called from the hot module replacement (HMR) when a file change is detected.
+// noinspection JSUnusedGlobalSymbols
+export let __reload = (m: {storeHolder: typeof storeHolder}) =>
+  m.storeHolder.store.take(1).subscribe((backupState: any) =>
+    AppModule.extendInitialState(backupState));
 
-
-const IMPORTS = [
-  HttpModule, // TODO: Why do we need this? It's just that the injector complains if it is missing.
-  APP_ROUTES,
-  InputModule,
-  TodosModule,
-  createStoreProvider(targetState)
-];
-
-@NgModule({
-  imports: IMPORTS,
-  providers: [appRoutingProviders],
-  declarations: [App],
-  bootstrap: [App]
-})
-export class AppModule {
-}
-
-export let __reload = (m: {storeHolder: typeof storeHolder}) => {
-  m.storeHolder.store.take(1).subscribe(toBeReloadedState => {
-    // toBeReloadedState => Entries from store from <before> the reload.
-    // targetState       => State to be used to initialize the store.
-    // Note: It seems that the initialization happens BEFORE this subscription is triggered for the first time,
-    // i.e. targetState need to be defined in advance, and the former state has to be assigned
-    // to the same object to properly get adopted to all components.
-    assign(targetState, toBeReloadedState);
-  });
-};
-
+// Defer the bootstrapping, so the __reload callback can be run by HMR before to recover the previous state.
+// The call of __reload is already registered when this initialization runs, so we can be sure that the
+// bootstrapping happens after the state recovery.
 setTimeout(() =>
   platformBrowserDynamic().bootstrapModule(AppModule)
     .then(ref => storeHolder.store = ref.injector.get(Store)));

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,31 +2,10 @@ import "zone.js";
 import "reflect-metadata";
 
 import {platformBrowserDynamic} from "@angular/platform-browser-dynamic";
-import {NgModule, enableProdMode} from "@angular/core";
-import {HttpModule} from "@angular/http";
+import {enableProdMode} from "@angular/core";
 
-import {App} from "./app/app.component";
-import {APP_ROUTES, appRoutingProviders} from "./app/app.routes";
-import {createStoreProvider} from "./app/app.store";
-import {InputModule} from "./app/inputTest/input.module";
-import {TodosModule} from "./app/todos/todos.module";
+import {AppModule} from "./app/app.module";
 
 enableProdMode();
-
-const IMPORTS = [
-  HttpModule, // TODO: Why do we need this? It's just that the injector complains if it is missing.
-  APP_ROUTES,
-  InputModule,
-  TodosModule,
-  createStoreProvider(),
-];
-
-@NgModule({
-  imports: IMPORTS,
-  providers: [appRoutingProviders],
-  bootstrap: [App]
-})
-export class AppModule {
-}
 
 platformBrowserDynamic().bootstrapModule(AppModule);


### PR DESCRIPTION
Using an app module, we are more DRY.
IMO the state handling in development also becomes more clear this way.

@DorianGrey 
