### PR TITLE
Update to 2.0.0 release

### DIFF
--- a/jspm.config.js
+++ b/jspm.config.js
@@ -62,19 +62,18 @@ SystemJS.config({
       'scss': 'github:KevCJones/plugin-scss@0.2.11',
       'systemjs-hot-reloader': 'github:capaj/systemjs-hot-reloader@0.6.0',
       'tty': 'github:jspm/nodelibs-tty@0.2.0-alpha',
-      'os': 'github:jspm/nodelibs-os@0.2.0-alpha',
       'plugin-typescript': 'github:frankwallis/plugin-typescript@5.1.2'
     },
     'packages': {
       'github:KevCJones/plugin-scss@0.2.11': {
         'map': {
-          'autoprefixer': 'npm:autoprefixer@6.3.7',
+          'autoprefixer': 'npm:autoprefixer@6.4.1',
           'fs': 'github:jspm/nodelibs-fs@0.1.2',
-          'lodash': 'npm:lodash@4.13.1',
+          'lodash': 'npm:lodash@4.15.0',
           'path': 'github:jspm/nodelibs-path@0.1.0',
-          'postcss': 'npm:postcss@5.1.0',
+          'postcss': 'npm:postcss@5.2.0',
           'reqwest': 'github:ded/reqwest@2.0.5',
-          'sass.js': 'npm:sass.js@0.9.11',
+          'sass.js': 'npm:sass.js@0.9.12',
           'url': 'github:jspm/nodelibs-url@0.1.0'
         }
       },
@@ -86,16 +85,6 @@ SystemJS.config({
       'github:jspm/nodelibs-url@0.1.0': {
         'map': {
           'url': 'npm:url@0.10.3'
-        }
-      },
-      'npm:autoprefixer@6.3.7': {
-        'map': {
-          'browserslist': 'npm:browserslist@1.3.5',
-          'caniuse-db': 'npm:caniuse-db@1.0.30000506',
-          'normalize-range': 'npm:normalize-range@0.1.2',
-          'num2fraction': 'npm:num2fraction@1.2.2',
-          'postcss': 'npm:postcss@5.1.0',
-          'postcss-value-parser': 'npm:postcss-value-parser@3.3.0'
         }
       },
       'npm:debug@2.2.0': {
@@ -114,11 +103,6 @@ SystemJS.config({
           'querystring': 'npm:querystring@0.2.0'
         }
       },
-      'github:jspm/nodelibs-os@0.2.0-alpha': {
-        'map': {
-          'os-browserify': 'npm:os-browserify@0.2.1'
-        }
-      },
       'github:frankwallis/plugin-typescript@5.1.2': {
         'map': {
           'typescript': 'npm:typescript@2.0.2'
@@ -131,16 +115,26 @@ SystemJS.config({
           'socket.io-client': 'github:socketio/socket.io-client@1.4.8'
         }
       },
-      'npm:postcss@5.1.0': {
+      'npm:autoprefixer@6.4.1': {
+        'map': {
+          'postcss': 'npm:postcss@5.2.0',
+          'browserslist': 'npm:browserslist@1.3.6',
+          'normalize-range': 'npm:normalize-range@0.1.2',
+          'num2fraction': 'npm:num2fraction@1.2.2',
+          'postcss-value-parser': 'npm:postcss-value-parser@3.3.0',
+          'caniuse-db': 'npm:caniuse-db@1.0.30000529'
+        }
+      },
+      'npm:browserslist@1.3.6': {
+        'map': {
+          'caniuse-db': 'npm:caniuse-db@1.0.30000529'
+        }
+      },
+      'npm:postcss@5.2.0': {
         'map': {
           'supports-color': 'npm:supports-color@3.1.2',
           'js-base64': 'npm:js-base64@2.1.9',
           'source-map': 'npm:source-map@0.5.6'
-        }
-      },
-      'npm:browserslist@1.3.5': {
-        'map': {
-          'caniuse-db': 'npm:caniuse-db@1.0.30000506'
         }
       }
     }
@@ -164,6 +158,7 @@ SystemJS.config({
     'github:*/*.json'
   ],
   map: {
+    'os': 'github:jspm/nodelibs-os@0.2.0-alpha',
     'assert': 'github:jspm/nodelibs-assert@0.2.0-alpha',
     'path': 'github:jspm/nodelibs-path@0.2.0-alpha',
     '@angular/router': 'npm:@angular/router@3.0.0',
@@ -184,10 +179,10 @@ SystemJS.config({
     'events': 'github:jspm/nodelibs-events@0.2.0-alpha',
     'fs': 'github:jspm/nodelibs-fs@0.2.0-alpha',
     'immutable': 'npm:immutable@3.8.1',
-    'lodash': 'npm:lodash@4.13.1',
+    'lodash': 'npm:lodash@4.15.0',
     'ng2-translate': 'npm:ng2-translate@2.5.0',
     'process': 'github:jspm/nodelibs-process@0.2.0-alpha',
-    'reflect-metadata': 'npm:reflect-metadata@0.1.3',
+    'reflect-metadata': 'npm:reflect-metadata@0.1.8',
     'rxjs': 'npm:rxjs@5.0.0-beta.12',
     'stream': 'github:jspm/nodelibs-stream@0.2.0-alpha',
     'string_decoder': 'github:jspm/nodelibs-string_decoder@0.2.0-alpha',
@@ -199,7 +194,7 @@ SystemJS.config({
   packages: {
     'github:jspm/nodelibs-buffer@0.2.0-alpha': {
       'map': {
-        'buffer-browserify': 'npm:buffer@4.7.1'
+        'buffer-browserify': 'npm:buffer@4.9.1'
       }
     },
     'github:jspm/nodelibs-crypto@0.2.0-alpha': {
@@ -220,10 +215,10 @@ SystemJS.config({
     'npm:browserify-aes@1.0.6': {
       'map': {
         'buffer-xor': 'npm:buffer-xor@1.0.3',
-        'cipher-base': 'npm:cipher-base@1.0.2',
+        'cipher-base': 'npm:cipher-base@1.0.3',
         'create-hash': 'npm:create-hash@1.1.2',
         'evp_bytestokey': 'npm:evp_bytestokey@1.0.0',
-        'inherits': 'npm:inherits@2.0.1'
+        'inherits': 'npm:inherits@2.0.3'
       }
     },
     'npm:browserify-cipher@1.0.0': {
@@ -235,43 +230,38 @@ SystemJS.config({
     },
     'npm:browserify-des@1.0.0': {
       'map': {
-        'cipher-base': 'npm:cipher-base@1.0.2',
+        'cipher-base': 'npm:cipher-base@1.0.3',
         'des.js': 'npm:des.js@1.0.0',
-        'inherits': 'npm:inherits@2.0.1'
+        'inherits': 'npm:inherits@2.0.3'
       }
     },
     'npm:browserify-rsa@4.0.1': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
+        'bn.js': 'npm:bn.js@4.11.6',
         'randombytes': 'npm:randombytes@2.0.3'
       }
     },
     'npm:browserify-sign@4.0.0': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
+        'bn.js': 'npm:bn.js@4.11.6',
         'browserify-rsa': 'npm:browserify-rsa@4.0.1',
         'create-hash': 'npm:create-hash@1.1.2',
         'create-hmac': 'npm:create-hmac@1.1.4',
         'elliptic': 'npm:elliptic@6.3.1',
-        'inherits': 'npm:inherits@2.0.1',
+        'inherits': 'npm:inherits@2.0.3',
         'parse-asn1': 'npm:parse-asn1@5.0.0'
-      }
-    },
-    'npm:cipher-base@1.0.2': {
-      'map': {
-        'inherits': 'npm:inherits@2.0.1'
       }
     },
     'npm:create-ecdh@4.0.0': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
+        'bn.js': 'npm:bn.js@4.11.6',
         'elliptic': 'npm:elliptic@6.3.1'
       }
     },
     'npm:create-hash@1.1.2': {
       'map': {
-        'cipher-base': 'npm:cipher-base@1.0.2',
-        'inherits': 'npm:inherits@2.0.1',
+        'cipher-base': 'npm:cipher-base@1.0.3',
+        'inherits': 'npm:inherits@2.0.3',
         'ripemd160': 'npm:ripemd160@1.0.1',
         'sha.js': 'npm:sha.js@2.4.5'
       }
@@ -279,7 +269,7 @@ SystemJS.config({
     'npm:create-hmac@1.1.4': {
       'map': {
         'create-hash': 'npm:create-hash@1.1.2',
-        'inherits': 'npm:inherits@2.0.1'
+        'inherits': 'npm:inherits@2.0.3'
       }
     },
     'npm:crypto-browserify@3.11.0': {
@@ -290,21 +280,21 @@ SystemJS.config({
         'create-hash': 'npm:create-hash@1.1.2',
         'create-hmac': 'npm:create-hmac@1.1.4',
         'diffie-hellman': 'npm:diffie-hellman@5.0.2',
-        'inherits': 'npm:inherits@2.0.1',
-        'pbkdf2': 'npm:pbkdf2@3.0.4',
+        'inherits': 'npm:inherits@2.0.3',
+        'pbkdf2': 'npm:pbkdf2@3.0.6',
         'public-encrypt': 'npm:public-encrypt@4.0.0',
         'randombytes': 'npm:randombytes@2.0.3'
       }
     },
     'npm:des.js@1.0.0': {
       'map': {
-        'inherits': 'npm:inherits@2.0.1',
+        'inherits': 'npm:inherits@2.0.3',
         'minimalistic-assert': 'npm:minimalistic-assert@1.0.0'
       }
     },
     'npm:diffie-hellman@5.0.2': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
+        'bn.js': 'npm:bn.js@4.11.6',
         'miller-rabin': 'npm:miller-rabin@4.0.0',
         'randombytes': 'npm:randombytes@2.0.3'
       }
@@ -316,13 +306,13 @@ SystemJS.config({
     },
     'npm:hash.js@1.0.3': {
       'map': {
-        'inherits': 'npm:inherits@2.0.1'
+        'inherits': 'npm:inherits@2.0.3'
       }
     },
     'npm:miller-rabin@4.0.0': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
-        'brorand': 'npm:brorand@1.0.5'
+        'bn.js': 'npm:bn.js@4.11.6',
+        'brorand': 'npm:brorand@1.0.6'
       }
     },
     'npm:parse-asn1@5.0.0': {
@@ -331,17 +321,12 @@ SystemJS.config({
         'browserify-aes': 'npm:browserify-aes@1.0.6',
         'create-hash': 'npm:create-hash@1.1.2',
         'evp_bytestokey': 'npm:evp_bytestokey@1.0.0',
-        'pbkdf2': 'npm:pbkdf2@3.0.4'
-      }
-    },
-    'npm:pbkdf2@3.0.4': {
-      'map': {
-        'create-hmac': 'npm:create-hmac@1.1.4'
+        'pbkdf2': 'npm:pbkdf2@3.0.6'
       }
     },
     'npm:public-encrypt@4.0.0': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
+        'bn.js': 'npm:bn.js@4.11.6',
         'browserify-rsa': 'npm:browserify-rsa@4.0.1',
         'create-hash': 'npm:create-hash@1.1.2',
         'parse-asn1': 'npm:parse-asn1@5.0.0',
@@ -350,45 +335,27 @@ SystemJS.config({
     },
     'npm:sha.js@2.4.5': {
       'map': {
-        'inherits': 'npm:inherits@2.0.1'
+        'inherits': 'npm:inherits@2.0.3'
       }
     },
     'npm:stream-browserify@2.0.1': {
       'map': {
-        'inherits': 'npm:inherits@2.0.1',
-        'readable-stream': 'npm:readable-stream@2.1.4'
-      }
-    },
-    'npm:readable-stream@2.1.4': {
-      'map': {
-        'inherits': 'npm:inherits@2.0.1',
-        'isarray': 'npm:isarray@1.0.0',
-        'string_decoder': 'npm:string_decoder@0.10.31',
-        'buffer-shims': 'npm:buffer-shims@1.0.0',
-        'core-util-is': 'npm:core-util-is@1.0.2',
-        'process-nextick-args': 'npm:process-nextick-args@1.0.7',
-        'util-deprecate': 'npm:util-deprecate@1.0.2'
+        'inherits': 'npm:inherits@2.0.3',
+        'readable-stream': 'npm:readable-stream@2.1.5'
       }
     },
     'npm:elliptic@6.3.1': {
       'map': {
-        'inherits': 'npm:inherits@2.0.1',
-        'bn.js': 'npm:bn.js@4.11.5',
+        'inherits': 'npm:inherits@2.0.3',
+        'bn.js': 'npm:bn.js@4.11.6',
         'hash.js': 'npm:hash.js@1.0.3',
-        'brorand': 'npm:brorand@1.0.5'
-      }
-    },
-    'npm:buffer@4.7.1': {
-      'map': {
-        'isarray': 'npm:isarray@1.0.0',
-        'ieee754': 'npm:ieee754@1.1.6',
-        'base64-js': 'npm:base64-js@1.1.2'
+        'brorand': 'npm:brorand@1.0.6'
       }
     },
     'npm:asn1.js@4.8.0': {
       'map': {
-        'bn.js': 'npm:bn.js@4.11.5',
-        'inherits': 'npm:inherits@2.0.1',
+        'bn.js': 'npm:bn.js@4.11.6',
+        'inherits': 'npm:inherits@2.0.3',
         'minimalistic-assert': 'npm:minimalistic-assert@1.0.0'
       }
     },
@@ -405,6 +372,39 @@ SystemJS.config({
     'npm:timers-browserify@1.4.2': {
       'map': {
         'process': 'npm:process@0.11.9'
+      }
+    },
+    'github:jspm/nodelibs-os@0.2.0-alpha': {
+      'map': {
+        'os-browserify': 'npm:os-browserify@0.2.1'
+      }
+    },
+    'npm:readable-stream@2.1.5': {
+      'map': {
+        'inherits': 'npm:inherits@2.0.3',
+        'buffer-shims': 'npm:buffer-shims@1.0.0',
+        'isarray': 'npm:isarray@1.0.0',
+        'core-util-is': 'npm:core-util-is@1.0.2',
+        'process-nextick-args': 'npm:process-nextick-args@1.0.7',
+        'string_decoder': 'npm:string_decoder@0.10.31',
+        'util-deprecate': 'npm:util-deprecate@1.0.2'
+      }
+    },
+    'npm:pbkdf2@3.0.6': {
+      'map': {
+        'create-hmac': 'npm:create-hmac@1.1.4'
+      }
+    },
+    'npm:cipher-base@1.0.3': {
+      'map': {
+        'inherits': 'npm:inherits@2.0.3'
+      }
+    },
+    'npm:buffer@4.9.1': {
+      'map': {
+        'isarray': 'npm:isarray@1.0.0',
+        'ieee754': 'npm:ieee754@1.1.6',
+        'base64-js': 'npm:base64-js@1.1.2'
       }
     }
   }

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -146,13 +146,13 @@ SystemJS.config({
     }
   },
   map: {
-    '@angular/router/testing': 'npm:@angular/router@3.0.0-rc.2/bundles/router-testing.umd.js',
-    '@angular/common/testing': 'npm:@angular/common@2.0.0-rc.6/bundles/common-testing.umd.js',
-    '@angular/compiler/testing': 'npm:@angular/compiler@2.0.0-rc.6/bundles/compiler-testing.umd.js',
-    '@angular/core/testing': 'npm:@angular/core@2.0.0-rc.6/bundles/core-testing.umd.js',
-    '@angular/http/testing': 'npm:@angular/http@2.0.0-rc.6/bundles/http-testing.umd.js',
-    '@angular/platform-browser/testing': 'npm:@angular/platform-browser@2.0.0-rc.6/bundles/platform-browser-testing.umd.js',
-    '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic@2.0.0-rc.6/bundles/platform-browser-dynamic-testing.umd.js',
+    '@angular/router/testing': 'npm:@angular/router@3.0.0/bundles/router-testing.umd.js',
+    '@angular/common/testing': 'npm:@angular/common@2.0.0/bundles/common-testing.umd.js',
+    '@angular/compiler/testing': 'npm:@angular/compiler@2.0.0/bundles/compiler-testing.umd.js',
+    '@angular/core/testing': 'npm:@angular/core@2.0.0/bundles/core-testing.umd.js',
+    '@angular/http/testing': 'npm:@angular/http@2.0.0/bundles/http-testing.umd.js',
+    '@angular/platform-browser/testing': 'npm:@angular/platform-browser@2.0.0/bundles/platform-browser-testing.umd.js',
+    '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic@2.0.0/bundles/platform-browser-dynamic-testing.umd.js',
     'store': 'npm:@ngrx/store@2.1.2'
   }
 });
@@ -166,15 +166,15 @@ SystemJS.config({
   map: {
     'assert': 'github:jspm/nodelibs-assert@0.2.0-alpha',
     'path': 'github:jspm/nodelibs-path@0.2.0-alpha',
-    '@angular/router': 'npm:@angular/router@3.0.0-rc.2',
-    '@angular/common': 'npm:@angular/common@2.0.0-rc.6',
-    '@angular/compiler': 'npm:@angular/compiler@2.0.0-rc.6',
-    '@angular/core': 'npm:@angular/core@2.0.0-rc.6',
-    '@angular/forms': 'npm:@angular/forms@2.0.0-rc.6',
-    '@angular/http': 'npm:@angular/http@2.0.0-rc.6',
-    '@angular/platform-browser': 'npm:@angular/platform-browser@2.0.0-rc.6',
-    '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic@2.0.0-rc.6',
-    '@ngrx/core': 'npm:@ngrx/core@1.1.0',
+    '@angular/router': 'npm:@angular/router@3.0.0',
+    '@angular/common': 'npm:@angular/common@2.0.0',
+    '@angular/compiler': 'npm:@angular/compiler@2.0.0',
+    '@angular/core': 'npm:@angular/core@2.0.0',
+    '@angular/forms': 'npm:@angular/forms@2.0.0',
+    '@angular/http': 'npm:@angular/http@2.0.0',
+    '@angular/platform-browser': 'npm:@angular/platform-browser@2.0.0',
+    '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic@2.0.0',
+    '@ngrx/core': 'npm:@ngrx/core@1.2.0',
     '@ngrx/store': 'npm:@ngrx/store@2.1.2',
     'buffer': 'github:jspm/nodelibs-buffer@0.2.0-alpha',
     'child_process': 'github:jspm/nodelibs-child_process@0.2.0-alpha',
@@ -185,15 +185,16 @@ SystemJS.config({
     'fs': 'github:jspm/nodelibs-fs@0.2.0-alpha',
     'immutable': 'npm:immutable@3.8.1',
     'lodash': 'npm:lodash@4.13.1',
-    'ng2-translate': 'npm:ng2-translate@2.4.3',
+    'ng2-translate': 'npm:ng2-translate@2.5.0',
     'process': 'github:jspm/nodelibs-process@0.2.0-alpha',
     'reflect-metadata': 'npm:reflect-metadata@0.1.3',
-    'rxjs': 'npm:rxjs@5.0.0-beta.11',
+    'rxjs': 'npm:rxjs@5.0.0-beta.12',
     'stream': 'github:jspm/nodelibs-stream@0.2.0-alpha',
     'string_decoder': 'github:jspm/nodelibs-string_decoder@0.2.0-alpha',
+    'timers': 'github:jspm/nodelibs-timers@0.2.0-alpha',
     'util': 'github:jspm/nodelibs-util@0.2.0-alpha',
     'vm': 'github:jspm/nodelibs-vm@0.2.0-alpha',
-    'zone.js': 'npm:zone.js@0.6.17'
+    'zone.js': 'npm:zone.js@0.6.23'
   },
   packages: {
     'github:jspm/nodelibs-buffer@0.2.0-alpha': {
@@ -391,9 +392,19 @@ SystemJS.config({
         'minimalistic-assert': 'npm:minimalistic-assert@1.0.0'
       }
     },
-    'npm:rxjs@5.0.0-beta.11': {
+    'npm:rxjs@5.0.0-beta.12': {
       'map': {
         'symbol-observable': 'npm:symbol-observable@1.0.2'
+      }
+    },
+    'github:jspm/nodelibs-timers@0.2.0-alpha': {
+      'map': {
+        'timers-browserify': 'npm:timers-browserify@1.4.2'
+      }
+    },
+    'npm:timers-browserify@1.4.2': {
+      'map': {
+        'process': 'npm:process@0.11.9'
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "devDependencies": {
       "json": "github:systemjs/plugin-json@^0.1.2",
       "net": "github:jspm/nodelibs-net@^0.2.0-alpha",
-      "os": "github:jspm/nodelibs-os@^0.2.0-alpha",
       "plugin-babel": "npm:systemjs-plugin-babel@^0.0.12",
       "plugin-typescript": "github:frankwallis/plugin-typescript@5.1.2",
       "scss": "github:KevCJones/plugin-scss@^0.2.11",
@@ -52,9 +51,10 @@
       "crypto": "github:jspm/nodelibs-crypto@^0.2.0-alpha",
       "events": "github:jspm/nodelibs-events@^0.2.0-alpha",
       "fs": "github:jspm/nodelibs-fs@^0.2.0-alpha",
+      "os": "github:jspm/nodelibs-os@^0.2.0-alpha",
       "path": "github:jspm/nodelibs-path@^0.2.0-alpha",
       "process": "github:jspm/nodelibs-process@^0.2.0-alpha",
-      "rxjs": "npm:rxjs@^5.0.0-beta.12",
+      "rxjs": "npm:rxjs@5.0.0-beta.12",
       "stream": "github:jspm/nodelibs-stream@^0.2.0-alpha",
       "string_decoder": "github:jspm/nodelibs-string_decoder@^0.2.0-alpha",
       "timers": "github:jspm/nodelibs-timers@^0.2.0-alpha",
@@ -137,7 +137,12 @@
           "util": "@node/util"
         }
       },
-      "npm:lodash@4.13.1": {
+      "npm:inherits@2.0.3": {
+        "ignore": [
+          "test.js"
+        ]
+      },
+      "npm:lodash@4.15.0": {
         "map": {
           "buffer": "@empty",
           "process": "@empty"
@@ -147,17 +152,12 @@
         "jspmNodeConversion": false,
         "format": "cjs"
       },
-      "npm:inherits@2.0.1": {
-        "ignore": [
-          "test.js"
-        ]
-      },
-      "npm:reflect-metadata@0.1.3": {
+      "npm:reflect-metadata@0.1.8": {
         "map": {
           "crypto": "@empty"
         }
       },
-      "npm:sass.js@0.9.11": {
+      "npm:sass.js@0.9.12": {
         "map": {
           "ws": "@empty"
         },
@@ -216,40 +216,40 @@
     "@angular/router": "^3.0.0",
     "@ngrx/core": "^1.2.0",
     "@ngrx/store": "^2.1.2",
-    "autoprefixer": "^6.4.0",
+    "autoprefixer": "^6.4.1",
     "chokidar": "^1.6.0",
     "chokidar-socket-emitter": "^0.5.4",
     "commander": "^2.9.0",
     "concurrently": "^2.2.0",
     "cssnano": "^3.7.4",
     "exorcist": "^0.4.0",
-    "glob": "^7.0.5",
+    "glob": "^7.0.6",
     "http-proxy": "^1.15.1",
     "immutable": "^3.8.1",
-    "jasmine-core": "2.4.1",
+    "jasmine-core": "2.5.1",
     "jasmine-reporters": "2.2.0",
     "js-yaml": "^3.6.1",
     "jspm": "^0.17.0-beta.28",
-    "karma": "^1.2.0",
+    "karma": "^1.3.0",
     "karma-jasmine": "1.0.2",
     "karma-jspm": "^2.2.0",
     "karma-junit-reporter": "^1.1.0",
     "karma-mocha-reporter": "^2.1.0",
-    "karma-phantomjs-launcher": "^1.0.1",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-sourcemap-loader": "^0.3.7",
     "livereload": "^0.5.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
     "ng2-translate": "^2.5.0",
-    "node-sass": "^3.8.0",
+    "node-sass": "^3.10.0",
     "phantomjs-prebuilt": "^2.1.12",
-    "postcss": "^5.1.2",
-    "postcss-cli": "^2.5.2",
+    "postcss": "^5.2.0",
+    "postcss-cli": "^2.6.0",
     "rimraf": "^2.5.4",
     "rxjs": "5.0.0-beta.12",
-    "stylelint": "^7.1.0",
+    "stylelint": "^7.2.0",
     "systemjs-hot-reloader": "^0.6.0",
-    "tslint": "^3.14.0",
+    "tslint": "^3.15.1",
     "typescript": "^2.0.2",
     "typings": "^1.3.2",
     "wait-for-change": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
       "lib": "src"
     },
     "dependencies": {
-      "@angular/forms": "npm:@angular/forms@^2.0.0-rc.6",
-      "@angular/router": "npm:@angular/router@^3.0.0-rc.2",
+      "@angular/forms": "npm:@angular/forms@^2.0.0",
+      "@angular/router": "npm:@angular/router@^3.0.0",
       "es6-shim": "github:es-shims/es6-shim@^0.35.0",
       "immutable": "npm:immutable@^3.8.1",
       "lodash": "npm:lodash@^4.13.1",
-      "ng2-translate": "npm:ng2-translate@^2.4.3",
+      "ng2-translate": "npm:ng2-translate@^2.5.0",
       "reflect-metadata": "npm:reflect-metadata@^0.1.3"
     },
     "devDependencies": {
@@ -37,13 +37,13 @@
       "tty": "github:jspm/nodelibs-tty@^0.2.0-alpha"
     },
     "peerDependencies": {
-      "@angular/common": "npm:@angular/common@^2.0.0-rc.6",
-      "@angular/compiler": "npm:@angular/compiler@^2.0.0-rc.6",
-      "@angular/core": "npm:@angular/core@^2.0.0-rc.6",
-      "@angular/http": "npm:@angular/http@2.0.0-rc.6",
-      "@angular/platform-browser": "npm:@angular/platform-browser@^2.0.0-rc.6",
-      "@angular/platform-browser-dynamic": "npm:@angular/platform-browser-dynamic@^2.0.0-rc.6",
-      "@ngrx/core": "npm:@ngrx/core@^1.1.0",
+      "@angular/common": "npm:@angular/common@^2.0.0",
+      "@angular/compiler": "npm:@angular/compiler@^2.0.0",
+      "@angular/core": "npm:@angular/core@^2.0.0",
+      "@angular/http": "npm:@angular/http@2.0.0",
+      "@angular/platform-browser": "npm:@angular/platform-browser@^2.0.0",
+      "@angular/platform-browser-dynamic": "npm:@angular/platform-browser-dynamic@^2.0.0",
+      "@ngrx/core": "npm:@ngrx/core@^1.2.0",
       "@ngrx/store": "npm:@ngrx/store@^2.1.2",
       "assert": "github:jspm/nodelibs-assert@^0.2.0-alpha",
       "buffer": "github:jspm/nodelibs-buffer@^0.2.0-alpha",
@@ -54,15 +54,16 @@
       "fs": "github:jspm/nodelibs-fs@^0.2.0-alpha",
       "path": "github:jspm/nodelibs-path@^0.2.0-alpha",
       "process": "github:jspm/nodelibs-process@^0.2.0-alpha",
-      "rxjs": "npm:rxjs@5.0.0-beta.11",
+      "rxjs": "npm:rxjs@^5.0.0-beta.12",
       "stream": "github:jspm/nodelibs-stream@^0.2.0-alpha",
       "string_decoder": "github:jspm/nodelibs-string_decoder@^0.2.0-alpha",
+      "timers": "github:jspm/nodelibs-timers@^0.2.0-alpha",
       "util": "github:jspm/nodelibs-util@^0.2.0-alpha",
       "vm": "github:jspm/nodelibs-vm@^0.2.0-alpha",
-      "zone.js": "npm:zone.js@^0.6.17"
+      "zone.js": "npm:zone.js@^0.6.23"
     },
     "overrides": {
-      "npm:@angular/common@2.0.0-rc.6": {
+      "npm:@angular/common@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -72,7 +73,7 @@
           }
         }
       },
-      "npm:@angular/compiler@2.0.0-rc.6": {
+      "npm:@angular/compiler@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -82,7 +83,7 @@
           }
         }
       },
-      "npm:@angular/core@2.0.0-rc.6": {
+      "npm:@angular/core@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -92,7 +93,7 @@
           }
         }
       },
-      "npm:@angular/http@2.0.0-rc.6": {
+      "npm:@angular/http@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -102,7 +103,7 @@
           }
         }
       },
-      "npm:@angular/platform-browser-dynamic@2.0.0-rc.6": {
+      "npm:@angular/platform-browser-dynamic@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -112,7 +113,7 @@
           }
         }
       },
-      "npm:@angular/platform-browser@2.0.0-rc.6": {
+      "npm:@angular/platform-browser@2.0.0": {
         "meta": {
           "src/*.js": {
             "deps": [
@@ -205,15 +206,15 @@
     "watch": "concurrently -r \"npm run watch-translations\" \"npm run watch-styles\" \"npm run watch-lint-scripts\" \"npm run watch-lint-styles\""
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.6",
-    "@angular/compiler": "^2.0.0-rc.6",
-    "@angular/core": "^2.0.0-rc.6",
-    "@angular/forms": "^2.0.0-rc.6",
-    "@angular/http": "^2.0.0-rc.6",
-    "@angular/platform-browser": "^2.0.0-rc.6",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.6",
-    "@angular/router": "^3.0.0-rc.2",
-    "@ngrx/core": "^1.1.0",
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0",
+    "@angular/http": "^2.0.0",
+    "@angular/platform-browser": "^2.0.0",
+    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@angular/router": "^3.0.0",
+    "@ngrx/core": "^1.2.0",
     "@ngrx/store": "^2.1.2",
     "autoprefixer": "^6.4.0",
     "chokidar": "^1.6.0",
@@ -223,7 +224,7 @@
     "cssnano": "^3.7.4",
     "exorcist": "^0.4.0",
     "glob": "^7.0.5",
-    "http-proxy": "^1.13.2",
+    "http-proxy": "^1.15.1",
     "immutable": "^3.8.1",
     "jasmine-core": "2.4.1",
     "jasmine-reporters": "2.2.0",
@@ -239,20 +240,20 @@
     "livereload": "^0.5.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1",
-    "ng2-translate": "^2.4.3",
+    "ng2-translate": "^2.5.0",
     "node-sass": "^3.8.0",
     "phantomjs-prebuilt": "^2.1.12",
     "postcss": "^5.1.2",
     "postcss-cli": "^2.5.2",
     "rimraf": "^2.5.4",
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-beta.12",
     "stylelint": "^7.1.0",
     "systemjs-hot-reloader": "^0.6.0",
     "tslint": "^3.14.0",
     "typescript": "^2.0.2",
     "typings": "^1.3.2",
     "wait-for-change": "^1.1.0",
-    "zone.js": "0.6.17"
+    "zone.js": "0.6.23"
   },
   "dependencies": {
     "express": "^4.14.0",


### PR DESCRIPTION
I've seen that a final 2.0.0 version was published this morning (w.r.t. to CEST). 
Thanks to all the work we've put into moving to RC.6, adopting to the release version is just about pushing deps.
I've added two commits:
- The first only refers to the 2.0.0 update and includes only the corresponding and immediately linked deps.
- The second refers to additional updates of various development and runtime dependencies and have been mentioned by `ncu` and `jspm update`.

@svi3c 
