### PR TITLE
Use a shared module for common imports and setup stuff.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,3 @@
-import each from "lodash/each";
 import indexOf from "lodash/indexOf";
 import {Component} from "@angular/core";
 import {TranslateService} from "ng2-translate/ng2-translate";
@@ -21,17 +20,13 @@ import styles from "./app.component.scss";
 })
 export class App {
 
-  currentLanguage: string = "en";
+  currentLanguage: string;
 
   private availableLanguages: string[];
 
   constructor(private translate: TranslateService) {
-    each(translations, (translation, lang) => {
-      this.translate.setTranslation(lang, translation);
-    });
+    this.currentLanguage = this.translate.currentLang;
     this.availableLanguages = Object.keys(translations);
-    this.translate.use(this.currentLanguage);
-
   }
 
   rotateLanguage() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,7 @@
 import {NgModule} from "@angular/core";
 import {HttpModule} from "@angular/http";
+import {BrowserModule} from "@angular/platform-browser";
+import {TranslateModule} from "ng2-translate";
 
 import assign from "lodash/assign";
 
@@ -8,12 +10,16 @@ import {APP_ROUTES, appRoutingProviders} from "./app.routes";
 import {createStoreProvider} from "./app.store";
 import {InputTestModule} from "./inputTest/inputTest.module";
 import {TodosModule} from "./todos/todos.module";
+import {SharedModule} from "./shared/shared.module";
 
 let initialState = {};
 
 const IMPORTS = [
+  BrowserModule, // Should only be imported by the root => every other module should import "CommonModule".
   HttpModule,
   APP_ROUTES,
+  TranslateModule.forRoot(),
+  SharedModule,
   InputTestModule,
   TodosModule,
   createStoreProvider(initialState)

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,9 +8,7 @@ const appRoutes: Routes = [
   }
 ];
 
-export const appRoutingProviders: any[] = [
-
-];
+export const appRoutingProviders: any[] = [];
 
 
 export const APP_ROUTES = RouterModule.forRoot(appRoutes);

--- a/src/app/inputTest/inputTest.module.ts
+++ b/src/app/inputTest/inputTest.module.ts
@@ -1,28 +1,13 @@
-/* @DorianGrey:
- From what I've read:
- https://github.com/angular/angular/issues/10472
- https://github.com/angular/angular/issues/10552
-
- The style below will be the default for >= RC.6 and is now already been used internally.
- Hope they'll reconsider this, since this might screw up most lazy loading techniques...
- */
-
 import {NgModule} from "@angular/core";
-import {BrowserModule} from "@angular/platform-browser";
-import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {InputTestComponent} from "./inputTest.component";
-import {TranslateModule} from "ng2-translate/ng2-translate";
 import {INPUT_TEST_ROUTES} from "./inputTest.routes";
+import {SharedModule} from "../shared/shared.module";
 
 @NgModule({
   imports: [
-    BrowserModule,
-    FormsModule,
-    ReactiveFormsModule,
-    TranslateModule.forRoot(),
+    SharedModule,
     INPUT_TEST_ROUTES
   ],
-  exports: [TranslateModule],
   declarations: [InputTestComponent]
 })
 export class InputTestModule {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,31 @@
+import {NgModule} from "@angular/core";
+import {CommonModule} from "@angular/common";
+import {FormsModule} from "@angular/forms";
+
+import {TranslateModule, TranslateService} from "ng2-translate/ng2-translate";
+import each from "lodash/each";
+
+import translations from "../../generated/translations";
+
+// See https://angular.io/docs/ts/latest/guide/ngmodule.html#!#shared-module
+// for an explanation of how to properly create and use a shared module.
+@NgModule({
+  imports: [
+    // Imported by app module, which imports this module.
+    // See description here: https://github.com/ocombe/ng2-translate/issues/232#issuecomment-251421577
+    TranslateModule
+  ],
+  exports: [
+    CommonModule,
+    FormsModule,
+    TranslateModule
+  ]
+})
+export class SharedModule {
+  constructor(translate: TranslateService) {
+    each(translations, (translation, lang) => {
+      translate.setTranslation(lang, translation);
+    });
+    translate.use("en");
+  }
+}

--- a/src/app/todos/todos.module.ts
+++ b/src/app/todos/todos.module.ts
@@ -1,21 +1,16 @@
 import {NgModule} from "@angular/core";
-import {BrowserModule} from "@angular/platform-browser";
-import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+
+import {SharedModule} from "../shared/shared.module";
 import {TodosComponent} from "./todos.component";
 import {TodoService} from "./todo.service";
-import {TranslateModule} from "ng2-translate/ng2-translate";
 import {TodoActionCreator} from "./todos.store";
 import {TODO_ROUTES} from "./todos.routes";
 
 @NgModule({
   imports: [
-    BrowserModule,
-    FormsModule,
-    ReactiveFormsModule,
-    TranslateModule.forRoot(),
+    SharedModule,
     TODO_ROUTES
   ],
-  exports: [TranslateModule],
   declarations: [TodosComponent],
   providers: [TodoService, TodoActionCreator]
 })


### PR DESCRIPTION
Extracted from https://github.com/flaviait/ng2-jspm-template/pull/38 .

This commit moves the code towards using a `SharedModule` for commom imports, i.e. the `CommonModule`, `FormsModule` and `TranslateModule`. It also changes the import of `BrowserModule` to `CommonModule` whereever possible, since the first should only be imported by the application root.

In addition, providing the translations to `TranslateService` is also part of the shared module, since it's not used as a component itself and thus more suitable here.

@svi3c 
