### PR TITLE
More strict options for the ts-compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "baseUrl": "."
   },
   "files": [


### PR DESCRIPTION
Since we've recently adopted tslint 4, which dropped some options that now may now be covered by the Typescript compiler itself, we should enable these options also. I've been using this combination in a production project, and it's also the default for this template's _evil brother_, and had good experience with this in both of them.

The only relaxing option is `suppressImplicitAnyIndexErrors` - it's often a rather complicated error to fix in a way the TS compiler likes it, so it's common to suppress it.

@svi3c 